### PR TITLE
Fix encryptor

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,7 @@
 name: Android CI
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Пофиксил велосипеды в шифровании.

1. Раньше для получения 16-байтного ключа из строки я её обрезал или дополнял пробелами. Сейчас считаю md5 от неё и использую этот хеш в качестве ключа.
2. Раньше вектор инициализации был константным, что не очень хорошо. Теперь генерируются 4 рандомных байта и дублируются 4 раза для получения вектора. Эти же 4 байта добавляю к конечным данным, чтобы можно было в итоге расшифровать. Короче, константный вектор инициализации - низкая безопасность. Можно было бы все 16 байт генерировать и добавлять в сообщение, но мне показалось это слишком расточительным в рамках смс. Но, если надо, можем все 16 генерировать.
3. Для того, чтобы была возможность отличить зашифрованную смс от другой смс в base64 (например, от Марша), раньше использовал сигнатуру. Если сигнатура не совпала, считаю сообщение незашифрованным и показываю в исходном виде, если совпала - показываю расшифрованное сообщение. Решил вместо захардкоженной константы использовать 1 байт хэша от данных. Польза от этого, наверное, небольшая, но хотя бы избавился от константы.

Ну и переключил actions в ручной режим.